### PR TITLE
Disable automatic running of evolutions on app load

### DIFF
--- a/server/app/com/fortysevendeg/exercises/ApplicationLoader.scala
+++ b/server/app/com/fortysevendeg/exercises/ApplicationLoader.scala
@@ -12,7 +12,6 @@ import doobie.contrib.hikari.hikaritransactor.HikariTransactor
 import doobie.util.transactor.{ DataSourceTransactor, Transactor }
 import play.api.ApplicationLoader.Context
 import play.api._
-import play.api.db.evolutions.{ DynamicEvolutions, EvolutionsComponents }
 import play.api.db.{ DBComponents, HikariCPComponents }
 import play.api.libs.ws._
 import play.api.libs.ws.ning.NingWSClient
@@ -35,7 +34,6 @@ class ExercisesApplicationLoader extends ApplicationLoader {
 
 class Components(context: Context)
     extends BuiltInComponentsFromContext(context)
-    with EvolutionsComponents
     with DBComponents
     with HikariCPComponents {
 
@@ -47,7 +45,7 @@ class Components(context: Context)
       url ← configuration.getString("db.default.url")
       parsed = url match {
         case jdbcUrl(user, pass, newUrl) ⇒ Some((user, pass, "jdbc:postgresql://" + newUrl))
-        case _                           ⇒ None
+        case _ ⇒ None
       }
       (user, pass, newUrl) ← parsed
       transactor = HikariTransactor[Task](driver, newUrl, user, pass).attemptRun match {
@@ -61,10 +59,6 @@ class Components(context: Context)
   }
 
   implicit val wsClient: WSClient = NingWSClient()
-
-  // touch lazy val to enable
-  applicationEvolutions
-  override def dynamicEvolutions: DynamicEvolutions = new DynamicEvolutions
 
   val applicationController = new ApplicationController
   val exercisesController = new ExercisesController

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -48,8 +48,8 @@ db.default.url=${?DATABASE_URL}
 # ~~~~~
 # You can disable evolutions if needed
 # evolutionplugin=disabled
-play.evolutions.db.default.autoApply=true
-#play.evolutions.db.default.autoApplyDowns=true
+play.evolutions.db.default.autoApply=false
+play.evolutions.db.default.autoApplyDowns=false
 
 # Logger
 # ~~~~~

--- a/server/conf/application.dev.conf
+++ b/server/conf/application.dev.conf
@@ -1,3 +1,5 @@
+play.evolutions.db.default.autoApply=true
+
 db.default.driver=org.postgresql.Driver
 db.default.url="jdbc:postgresql://localhost:5432/scalaexercises_dev"
 db.default.username=scalaexercises_dev_user

--- a/server/test/com/fortysevendeg/exercises/persistence/repositories/UserProgressRepositorySpec.scala
+++ b/server/test/com/fortysevendeg/exercises/persistence/repositories/UserProgressRepositorySpec.scala
@@ -40,7 +40,7 @@ class UserProgressRepositorySpec
   } yield maybeUser.toOption.get
 
   ignore("new user progress records can be created") {
-    forAll(maxDiscardedFactor(10)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
+    forAll(maxDiscarded(10000)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
       val tx: ConnectionIO[Boolean] = for {
         user ← newUser(usr)
         progress = prg.copy(user = user)
@@ -53,7 +53,7 @@ class UserProgressRepositorySpec
   }
 
   ignore("existing user progress records can be updated") {
-    forAll(maxDiscardedFactor(10)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request, someArgs: List[String]) ⇒
+    forAll(maxDiscarded(10000)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request, someArgs: List[String]) ⇒
       val tx: ConnectionIO[Boolean] = for {
         user ← newUser(usr)
         progress = prg.copy(user = user)
@@ -67,7 +67,7 @@ class UserProgressRepositorySpec
   }
 
   ignore("user progress can be fetched by section") {
-    forAll(maxDiscardedFactor(10)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
+    forAll(maxDiscarded(10000)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
       val tx: ConnectionIO[Boolean] = for {
         user ← newUser(usr)
         progress = prg.copy(user = user)
@@ -80,7 +80,7 @@ class UserProgressRepositorySpec
   }
 
   ignore("user progress can be fetched by exercise") {
-    forAll(maxDiscardedFactor(10)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
+    forAll(maxDiscarded(10000)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
       val tx: ConnectionIO[Boolean] = for {
         user ← newUser(usr)
         progress = prg.copy(user = user)
@@ -100,7 +100,7 @@ class UserProgressRepositorySpec
   }
 
   ignore("users progress can be queried by their ID") {
-    forAll(maxDiscardedFactor(10000)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
+    forAll(maxDiscarded(10000)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
       val tx: ConnectionIO[Boolean] = for {
         user ← newUser(usr)
         progress = prg.copy(user = user)
@@ -116,7 +116,7 @@ class UserProgressRepositorySpec
   }
 
   ignore("user progress can be deleted") {
-    forAll(maxDiscardedFactor(10)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
+    forAll(maxDiscarded(10000)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
       val tx: ConnectionIO[Boolean] = for {
         user ← newUser(usr)
         userProgress ← repository.create(prg.copy(user = user))
@@ -129,7 +129,7 @@ class UserProgressRepositorySpec
   }
 
   ignore("all user progress records can be deleted") {
-    forAll(maxDiscardedFactor(10)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
+    forAll(maxDiscarded(10000)) { (usr: UserCreation.Request, prg: SaveUserProgress.Request) ⇒
       val tx: ConnectionIO[Boolean] = for {
         user ← newUser(usr)
         userProgress ← repository.create(prg.copy(user = user))


### PR DESCRIPTION
@raulraja @rafaparadela plz take a look, this will avoid running evolutions automatically in production. During development, Play will detect schema changes and prompt you to apply them when running the app.