### PR TITLE
GitHub interaction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,7 @@ lazy val server = (project in file("server"))
       "org.webjars" % "highlightjs" % "8.7",
       "org.webjars.npm" % "highlight.js" % "9.1.0",
       "com.tristanhunt" %% "knockoff" % "0.8.3",
+      "com.fortysevendeg" %% "github4s" % "0.2-SNAPSHOT",
       "org.scala-lang" % "scala-compiler" % scalaVersion.value,
       "org.scalaz" %% "scalaz-concurrent" % scalazVersion,
       "org.tpolecat" %% "doobie-core" % doobieVersion exclude("org.scalaz", "scalaz-concurrent"),

--- a/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/TreeGen.scala
+++ b/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/TreeGen.scala
@@ -41,7 +41,8 @@ case class TreeGen[U <: Universe](
   def makeSection(
     name: String, description: Option[String],
     exerciseTerms: List[TermName],
-    imports: List[String]
+    imports: List[String],
+    path: Option[String] = None
   ) = {
     val term = makeTermName("Section", name)
     term → q"""
@@ -50,12 +51,13 @@ case class TreeGen[U <: Universe](
           override val description  = $description
           override val exercises    = $exerciseTerms
           override val imports      = $imports
+          override val path         = $path
         }"""
   }
 
   def makeLibrary(
     name: String, description: String, color: Option[String],
-    sectionTerms: List[TermName]
+    sectionTerms: List[TermName], owner: String, repository: String
   ) = {
     val term = makeTermName("Library", name)
     term → q"""
@@ -64,6 +66,8 @@ case class TreeGen[U <: Universe](
           override val description  = $description
           override val color        = $color
           override val sections     = $sectionTerms
+          override val owner        = $owner
+          override val repository   = $repository
         }"""
   }
 

--- a/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/CompilerSpec.scala
+++ b/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/CompilerSpec.scala
@@ -20,6 +20,8 @@ class CompilerSpec extends FunSpec with Matchers {
         * @param name Sample Library
         */
       object SampleLibrary extends exercise.Library {
+        override def owner = "scala-exercises"
+        override def repository = "site"
         override def sections = List(
           Section1
         )
@@ -49,7 +51,8 @@ class CompilerSpec extends FunSpec with Matchers {
         .getField("MODULE$").get(null)
         .asInstanceOf[exercise.Library]
 
-      val res = Compiler().compile(library, code :: Nil, "sample")
+      val path = "(internal)"
+      val res = Compiler().compile(library, code :: Nil, path :: Nil, "/", "sample")
       assert(res.isRight, s"""; ${res.fold(identity, _ ⇒ "")}""")
     }
   }

--- a/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/SourceTextExtractionSpec.scala
+++ b/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/SourceTextExtractionSpec.scala
@@ -33,7 +33,7 @@ class SourceTextExtractionSpec extends FunSpec with Matchers with Inside {
       }
       """
 
-    val res = new SourceTextExtraction().extractAll(code :: Nil)
+    val res = new SourceTextExtraction().extractAll(code :: Nil, List("(internal)"), "/")
 
     it("should find all doc comments on classes and objects") {
       res.comments.map { case (k, v) ⇒ k.mkString(".") → v.raw } should equal(Map(
@@ -79,7 +79,8 @@ class SourceTextExtractionSpec extends FunSpec with Matchers with Inside {
         }
         """
 
-      val res = new SourceTextExtraction().extractAll(source1 :: source2 :: Nil)
+      val paths = List("(internal)", "(internal)")
+      val res = new SourceTextExtraction().extractAll(source1 :: source2 :: Nil, paths, "/")
 
       // Should capture exactly 1 import for Object1.method
       inside(res.methods.get("Object1" :: "method" :: Nil)) {

--- a/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/TreeGenSpec.scala
+++ b/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/TreeGenSpec.scala
@@ -56,7 +56,9 @@ class TreeGenSpec extends FunSpec with Matchers {
         name = "MyLibrary",
         description = "This is my library",
         color = Some("#FFFFFF"),
-        sectionTerms = sections.map(_._1)
+        sectionTerms = sections.map(_._1),
+        owner = "scala-exercises",
+        repository = "site"
       )
 
       val tree = treeGen.makePackage(

--- a/definitions/src/main/scala/exercise/Library.scala
+++ b/definitions/src/main/scala/exercise/Library.scala
@@ -9,6 +9,8 @@ package exercise
  * Marker trait for exercise libraries.
  */
 trait Library {
+  def owner: String
+  def repository: String
   def sections: List[Section]
   def color: Option[String] = None
 }

--- a/runtime/src/main/scala/com/fortysevendeg/exercises/Exercises.scala
+++ b/runtime/src/main/scala/com/fortysevendeg/exercises/Exercises.scala
@@ -28,14 +28,14 @@ object Exercises {
     ClassFinder.classInfoMap(classes)
   }
 
-  private[this] def subclassesOf[A: ClassTag](cl: ClassLoader) : List[String] = {
-    def loop(currentClassLoader : ClassLoader, acc : List[String]) : List[String] = Option(currentClassLoader) match {
+  private[this] def subclassesOf[A: ClassTag](cl: ClassLoader): List[String] = {
+    def loop(currentClassLoader: ClassLoader, acc: List[String]): List[String] = Option(currentClassLoader) match {
       case None => acc
-      case Some(cll : URLClassLoader) =>
+      case Some(cll: URLClassLoader) =>
         val cn = ClassFinder.concreteSubclasses(implicitly[ClassTag[A]].runtimeClass.getName, classMap(cll))
-            .filter(_.name.startsWith(LIBRARIES_PACKAGE))
-            .map(_.name)
-            .toList
+          .filter(_.name.startsWith(LIBRARIES_PACKAGE))
+          .map(_.name)
+          .toList
         loop(currentClassLoader.getParent, acc ++ cn)
       case Some(o) => loop(o.getParent, acc)
     }

--- a/runtime/src/main/scala/com/fortysevendeg/exercises/model.scala
+++ b/runtime/src/main/scala/com/fortysevendeg/exercises/model.scala
@@ -11,6 +11,8 @@ package com.fortysevendeg.exercises
  * An exercise library.
  */
 trait Library {
+  def owner: String
+  def repository: String
   def name: String
   def description: String
   def color: Option[String]
@@ -25,6 +27,7 @@ trait Section {
   def description: Option[String]
   def exercises: List[Exercise]
   def imports: List[String]
+  def path: Option[String]
 }
 
 /**
@@ -42,6 +45,8 @@ trait Exercise {
 
 // default case class implementations
 case class DefaultLibrary(
+  owner: String,
+  repository: String,
   name: String,
   description: String,
   color: Option[String],
@@ -52,7 +57,8 @@ case class DefaultSection(
   name: String,
   description: Option[String],
   exercises: List[Exercise] = Nil,
-  imports: List[String] = Nil
+  imports: List[String] = Nil,
+  path: Option[String] = None
 ) extends Section
 
 case class DefaultExercise(

--- a/runtime/src/test/scala/com/fortysevendeg/exercises/Content.scala
+++ b/runtime/src/test/scala/com/fortysevendeg/exercises/Content.scala
@@ -3,6 +3,8 @@ package defaultLib
 import com.fortysevendeg.exercises.Library
 
 object LibraryA extends Library {
+  override def owner = ???
+  override def repository = ???
   override def color = ???
   override def description = ???
   override def name = ???
@@ -10,6 +12,8 @@ object LibraryA extends Library {
 }
 
 object LibraryB extends Library {
+  override def owner = ???
+  override def repository = ???
   override def color = ???
   override def description = ???
   override def name = ???
@@ -17,6 +21,8 @@ object LibraryB extends Library {
 }
 
 object LibraryC extends Library {
+  override def owner = ???
+  override def repository = ???
   override def color = ???
   override def description = ???
   override def name = ???
@@ -24,6 +30,8 @@ object LibraryC extends Library {
 }
 
 class ErrorLibrary extends Library {
+  override def owner = ???
+  override def repository = ???
   override def color = ???
   override def description = ???
   override def name = ???

--- a/server/app/com/fortysevendeg/exercises/ApplicationLoader.scala
+++ b/server/app/com/fortysevendeg/exercises/ApplicationLoader.scala
@@ -63,7 +63,7 @@ class Components(context: Context)
   val applicationController = new ApplicationController
   val exercisesController = new ExercisesController
   val userController = new UserController
-  val oauthController = new OAuth2Controller
+  val oauthController = new OAuthController
   val userProgressController = new UserProgressController
 
   val assets = new _root_.controllers.Assets(httpErrorHandler)

--- a/server/app/com/fortysevendeg/exercises/app.scala
+++ b/server/app/com/fortysevendeg/exercises/app.scala
@@ -13,5 +13,6 @@ import com.fortysevendeg.exercises.services.free._
 object app {
   type C01[A] = Coproduct[ExerciseOp, UserOp, A]
   type C02[A] = Coproduct[UserProgressOp, C01, A]
-  type ExercisesApp[A] = Coproduct[DBResult, C02, A]
+  type C03[A] = Coproduct[GithubOp, C02, A]
+  type ExercisesApp[A] = Coproduct[DBResult, C03, A]
 }

--- a/server/app/com/fortysevendeg/exercises/controllers/ApplicationController.scala
+++ b/server/app/com/fortysevendeg/exercises/controllers/ApplicationController.scala
@@ -6,13 +6,16 @@
 package com.fortysevendeg.exercises.controllers
 
 import java.util.UUID
++import com.fortysevendeg.exercises.services.interpreters.ProdInterpreters
++import com.fortysevendeg.github4s.Github
++import com.fortysevendeg.github4s.free.domain.Commit
++import shared.{ Contribution, Contributor, Contributions }
 import scala.collection.JavaConverters._
 
 import cats.data.Xor
 import com.fortysevendeg.exercises.app._
 import com.fortysevendeg.exercises.services.free._
 import com.fortysevendeg.exercises.services.ExercisesService
-import com.fortysevendeg.exercises.services.interpreters.ProdInterpreters
 import com.fortysevendeg.exercises.utils.OAuth2
 import com.fortysevendeg.shared.free.ExerciseOps
 import doobie.imports._
@@ -30,6 +33,7 @@ class ApplicationController(
     exerciseOps: ExerciseOps[ExercisesApp],
     userOps: UserOps[ExercisesApp],
     userProgressOps: UserProgressOps[ExercisesApp],
+    githubOps:       GithubOps[ExercisesApp],
     T: Transactor[Task]
 ) extends Controller with AuthenticationModule with ProdInterpreters {
   implicit def application: Application = Play.current
@@ -37,17 +41,17 @@ class ApplicationController(
   lazy val topLibraries: List[String] = application.configuration.getStringList("exercises.top_libraries") map (_.asScala.toList) getOrElse Nil
 
   def index = Action.async { implicit request ⇒
-    val (redirectUrl, state) = authStatus
 
     val ops = for {
+      authorize ← githubOps.getAuthorizeUrl(OAuth2.githubAuthId, OAuth2.callbackUrl)
       libraries ← exerciseOps.getLibraries.map(ExercisesService.reorderLibraries(topLibraries, _))
       user ← userOps.getUserByLogin(request.session.get("user").getOrElse(""))
       progress ← userProgressOps.fetchMaybeUserProgress(user)
-    } yield (libraries, user, request.session.get("oauth-token"), progress)
+    } yield (libraries, user, request.session.get("oauth-token"), progress, authorize)
 
     ops.runFuture map {
-      case Xor.Right((libraries, user, Some(token), progress)) ⇒ Ok(views.html.templates.home.index(user = user, libraries = libraries, progress = progress))
-      case Xor.Right((libraries, None, None, progress)) ⇒ Ok(views.html.templates.home.index(user = None, libraries = libraries, redirectUrl = Option(redirectUrl), progress = progress)).withSession("oauth-state" → state)
+      case Xor.Right((libraries, user, Some(token), progress, _)) ⇒ Ok(views.html.templates.home.index(user = user, libraries = libraries, progress = progress))
+      case Xor.Right((libraries, None, None, progress, authorize)) ⇒ Ok(views.html.templates.home.index(user = None, libraries = libraries, progress = progress, redirectUrl = Option(authorize.url))).withSession("oauth-state" → authorize.state)
       case Xor.Left(ex) ⇒ InternalServerError(ex.getMessage)
     }
   }
@@ -60,36 +64,42 @@ class ApplicationController(
   }
 
   def section(libraryName: String, sectionName: String) = Action.async { implicit request ⇒
-    val (redirectUrl, state) = authStatus
     val ops = for {
+      authorize ← githubOps.getAuthorizeUrl(OAuth2.githubAuthId, OAuth2.callbackUrl)
       libraries ← exerciseOps.getLibraries
       section ← exerciseOps.getSection(libraryName, sectionName)
+      commits ← githubOps.getContributions(OAuth2.githubOwner, OAuth2.githubRepo, section.flatMap(_.path).getOrElse(""))
+      contributions = commitsToContributions(commits)
       user ← userOps.getUserByLogin(request.session.get("user").getOrElse(""))
       libProgress ← userProgressOps.fetchMaybeUserProgressByLibrary(user, libraryName)
-    } yield (libraries.find(_.name == libraryName), section, user, request.session.get("oauth-token"), libProgress)
+    } yield (libraries.find(_.name == libraryName), section, user, request.session.get("oauth-token"), libProgress, authorize, contributions)
     ops.runFuture map {
-      case Xor.Right((Some(l), Some(s), user, Some(token), libProgress)) ⇒ {
-        Ok(
-          views.html.templates.library.index(
-            library = l,
-            section = s,
-            user = user,
-            progress = libProgress
-          )
-        )
-      }
-      case Xor.Right((Some(l), Some(s), user, None, libProgress)) ⇒ {
+      case Xor.Right((Some(l), Some(s), user, Some(token), libProgress, _, contributions)) ⇒ {
         Ok(
           views.html.templates.library.index(
             library = l,
             section = s,
             user = user,
             progress = libProgress,
-            redirectUrl = Option(redirectUrl)
+            contributions = contributions,
+            githubBaseUrl = OAuth2.githubOwner + "/" + OAuth2.githubRepo
+          )
+        )
+      }
+      case Xor.Right((Some(l), Some(s), user, None, libProgress, authorize, contributions)) ⇒ {
+        Ok(
+          views.html.templates.library.index(
+            library = l,
+            section = s,
+            user = user,
+            progress = libProgress,
+            redirectUrl = Option(authorize.url),
+            contributions = contributions,
+            githubBaseUrl = OAuth2.githubOwner + "/" + OAuth2.githubRepo
           )
         ).withSession("oauth-state" → state)
       }
-      case Xor.Right((Some(l), None, _, _, _)) ⇒ Redirect(l.sectionNames.head)
+      case Xor.Right((Some(l), None, _, _, _, _, _))) ⇒ Redirect(l.sectionNames.head)
       case _ ⇒ Ok("Section not found")
     }
   }
@@ -104,13 +114,16 @@ class ApplicationController(
     ).as("text/javascript")
   }
 
-  def authStatus(implicit req: Request[AnyContent]): (String, String) = {
-    // NOTE: An empty OAuth scope indicates access to public info only
-    val scope = ""
-    val state = UUID.randomUUID().toString
-    val callbackUrl = com.fortysevendeg.exercises.utils.routes.OAuth2Controller.callback(None, None).absoluteURL()
-    val redirectUrl = OAuth2.getAuthorizationUrl(callbackUrl, scope, state)
-    (redirectUrl, state)
-  }
+  private def commitsToContributions(commits: List[Commit]): Contributions =
+    Contributions(toContribution(commits), commitsToContributors(commits))
+
+  private def toContribution(commits: List[Commit]): List[Contribution] =
+    commits.map(c ⇒ Contribution(c.sha, c.message, c.date, c.url, c.login, c.avatar_url, c.author_url))
+
+  private def commitsToContributors(commits: List[Commit]): List[Contributor] = commits
+      .groupBy(c ⇒ (c.login, c.avatar_url, c.author_url))
+      .keys
+      .map { case (login, avatar, url) ⇒ Contributor(login, avatar, url) }
+      .toList
 
 }

--- a/server/app/com/fortysevendeg/exercises/controllers/OAuthController.scala
+++ b/server/app/com/fortysevendeg/exercises/controllers/OAuthController.scala
@@ -1,0 +1,67 @@
+/*
+ * scala-exercises-server
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
+package com.fortysevendeg.exercises.controllers
+
+import cats.data.Xor
+import cats.std.option._
+import cats.syntax.cartesian._
+import com.fortysevendeg.exercises.app._
+import com.fortysevendeg.exercises.persistence.domain.UserCreation
+import com.fortysevendeg.exercises.services.free.{ GithubOps, UserOps }
+import com.fortysevendeg.exercises.services.interpreters.FreeExtensions._
+import com.fortysevendeg.exercises.services.interpreters.ProdInterpreters
+import com.fortysevendeg.exercises.utils.OAuth2._
+import doobie.imports._
+import play.api.mvc.{ Action, Controller }
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scalaz.concurrent.Task
+
+class OAuthController(
+    implicit
+    userOps:   UserOps[ExercisesApp],
+    githubOps: GithubOps[ExercisesApp],
+    T:         Transactor[Task]
+) extends Controller with ProdInterpreters {
+
+  def callback(codeOpt: Option[String] = None, stateOpt: Option[String] = None) = Action.async { implicit request ⇒
+    Future {
+      (codeOpt |@| stateOpt |@| request.session.get("oauth-state")).tupled
+          .fold(BadRequest("Missing `code` or `state`")) {
+            case (code, state, oauthState) ⇒
+              if (state == oauthState) {
+                githubOps.getAccessToken(githubAuthId, githubAuthSecret, code, callbackUrl, state).runTask match {
+                  case Xor.Right(a) ⇒ Redirect(successUrl).withSession("oauth-token" → a.access_token)
+                  case Xor.Left(ex) ⇒ Unauthorized(ex.getMessage)
+                }
+              } else BadRequest("Invalid github login")
+          }
+    }
+  }
+
+  def success() = Action.async { implicit request ⇒
+    Future {
+      request.session.get("oauth-token").fold(Unauthorized("Missing OAuth token")) { accessToken ⇒
+        val ops = for {
+          ghuser ← githubOps.getAuthUser(Some(accessToken))
+          user ← userOps.getOrCreate(UserCreation.toUser(ghuser))
+        } yield (ghuser, user)
+
+        ops.runTask match {
+          case Xor.Right((ghu, u)) ⇒ Redirect(request.headers.get("referer") match {
+            case Some(url) if !url.contains("github") ⇒ url
+            case _                                    ⇒ "/"
+          }).withSession("oauth-token" → accessToken, "user" → ghu.login)
+          case Xor.Left(_) ⇒ InternalServerError("Failed to save user information")
+        }
+      }
+    }
+  }
+
+  def logout() = Action(Redirect("/").withNewSession)
+
+}

--- a/server/app/com/fortysevendeg/exercises/persistence/domain/UserQueries.scala
+++ b/server/app/com/fortysevendeg/exercises/persistence/domain/UserQueries.scala
@@ -6,6 +6,7 @@
 package com.fortysevendeg.exercises.persistence.domain
 
 import cats.data.Xor
+import com.fortysevendeg.github4s.free.domain.{ User ⇒ GHUser }
 import shared.User
 import shapeless._
 import ops.record._
@@ -28,6 +29,8 @@ object UserCreation {
     def asUser(id: Long): User =
       User(id, login, name, githubId, pictureUrl, githubUrl, email)
   }
+
+  def toUser(ghu: GHUser) = Request(ghu.login, ghu.name, ghu.id.toString, ghu.avatar_url, ghu.html_url, ghu.email)
 
   type Response = CreationError Xor User
 }

--- a/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
+++ b/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
@@ -129,6 +129,8 @@ sealed trait RuntimeSharedConversions {
           case Nil ⇒ None → Nil
         }
         colors0 → (DefaultLibrary(
+          owner = library.owner,
+          repository = library.repository,
           name = library.name,
           description = library.description,
           color = color,
@@ -142,6 +144,8 @@ sealed trait RuntimeSharedConversions {
 
   def convertLibrary(library: Library) =
     shared.Library(
+      owner = library.owner,
+      repository = library.repository,
       name = library.name,
       description = library.description,
       color = library.color getOrElse "black",

--- a/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
+++ b/server/app/com/fortysevendeg/exercises/services/ExercisesService.scala
@@ -152,6 +152,7 @@ sealed trait RuntimeSharedConversions {
     shared.Section(
       name = section.name,
       description = section.description,
+      path = section.path,
       exercises = section.exercises.map(convertExercise)
     )
 

--- a/server/app/com/fortysevendeg/exercises/services/free/GithubOps.scala
+++ b/server/app/com/fortysevendeg/exercises/services/free/GithubOps.scala
@@ -4,46 +4,48 @@ import cats.free.Free
 import cats.free.Inject
 import com.fortysevendeg.github4s.free.domain.{ Commit, User, OAuthToken, Authorize }
 
-/** GitHub Ops GADT
-  */
+/**
+ * GitHub Ops GADT
+ */
 sealed trait GithubOp[A]
 
 final case class GetAuthorizeUrl(
-    clientId:    String,
-    redirectUri: String,
-    scopes:      List[String]
+  clientId: String,
+  redirectUri: String,
+  scopes: List[String]
 ) extends GithubOp[Authorize]
 
 final case class GetAccessToken(
-    clientId:     String,
-    clientSecret: String,
-    code:         String,
-    redirectUri:  String,
-    state:        String
+  clientId: String,
+  clientSecret: String,
+  code: String,
+  redirectUri: String,
+  state: String
 ) extends GithubOp[OAuthToken]
 
 final case class GetAuthUser(accessToken: Option[String] = None) extends GithubOp[User]
 
 final case class GetContributions(owner: String, repo: String, path: String) extends GithubOp[List[Commit]]
 
-/** Exposes GitHub operations as a Free monadic algebra that may be combined with other Algebras via
-  * Coproduct
-  */
+/**
+ * Exposes GitHub operations as a Free monadic algebra that may be combined with other Algebras via
+ * Coproduct
+ */
 class GithubOps[F[_]](implicit I: Inject[GithubOp, F]) {
 
   def getAuthorizeUrl(
-      clientId:    String,
-      redirectUri: String,
-      scopes:      List[String] = List.empty
+    clientId: String,
+    redirectUri: String,
+    scopes: List[String] = List.empty
   ): Free[F, Authorize] =
     Free.inject[GithubOp, F](GetAuthorizeUrl(clientId, redirectUri, scopes))
 
   def getAccessToken(
-      clientId:      String,
-      clienteSecret: String,
-      code:          String,
-      redirectUri:   String,
-      state:         String
+    clientId: String,
+    clienteSecret: String,
+    code: String,
+    redirectUri: String,
+    state: String
   ): Free[F, OAuthToken] =
     Free.inject[GithubOp, F](GetAccessToken(clientId, clienteSecret, code, redirectUri, state))
 
@@ -54,8 +56,9 @@ class GithubOps[F[_]](implicit I: Inject[GithubOp, F]) {
 
 }
 
-/** Default implicit based DI factory from which instances of the GuthubOps may be obtained
-  */
+/**
+ * Default implicit based DI factory from which instances of the GuthubOps may be obtained
+ */
 object GithubOps {
   implicit def instance[F[_]](implicit I: Inject[GithubOp, F]): GithubOps[F] = new GithubOps[F]
 }

--- a/server/app/com/fortysevendeg/exercises/services/free/GithubOps.scala
+++ b/server/app/com/fortysevendeg/exercises/services/free/GithubOps.scala
@@ -1,0 +1,61 @@
+package com.fortysevendeg.exercises.services.free
+
+import cats.free.Free
+import cats.free.Inject
+import com.fortysevendeg.github4s.free.domain.{ Commit, User, OAuthToken, Authorize }
+
+/** GitHub Ops GADT
+  */
+sealed trait GithubOp[A]
+
+final case class GetAuthorizeUrl(
+    clientId:    String,
+    redirectUri: String,
+    scopes:      List[String]
+) extends GithubOp[Authorize]
+
+final case class GetAccessToken(
+    clientId:     String,
+    clientSecret: String,
+    code:         String,
+    redirectUri:  String,
+    state:        String
+) extends GithubOp[OAuthToken]
+
+final case class GetAuthUser(accessToken: Option[String] = None) extends GithubOp[User]
+
+final case class GetContributions(owner: String, repo: String, path: String) extends GithubOp[List[Commit]]
+
+/** Exposes GitHub operations as a Free monadic algebra that may be combined with other Algebras via
+  * Coproduct
+  */
+class GithubOps[F[_]](implicit I: Inject[GithubOp, F]) {
+
+  def getAuthorizeUrl(
+      clientId:    String,
+      redirectUri: String,
+      scopes:      List[String] = List.empty
+  ): Free[F, Authorize] =
+    Free.inject[GithubOp, F](GetAuthorizeUrl(clientId, redirectUri, scopes))
+
+  def getAccessToken(
+      clientId:      String,
+      clienteSecret: String,
+      code:          String,
+      redirectUri:   String,
+      state:         String
+  ): Free[F, OAuthToken] =
+    Free.inject[GithubOp, F](GetAccessToken(clientId, clienteSecret, code, redirectUri, state))
+
+  def getAuthUser(accessToken: Option[String] = None): Free[F, User] = Free.inject[GithubOp, F](GetAuthUser(accessToken))
+
+  def getContributions(owner: String, repo: String, path: String): Free[F, List[Commit]] =
+    Free.inject[GithubOp, F](GetContributions(owner, repo, path))
+
+}
+
+/** Default implicit based DI factory from which instances of the GuthubOps may be obtained
+  */
+object GithubOps {
+  implicit def instance[F[_]](implicit I: Inject[GithubOp, F]): GithubOps[F] = new GithubOps[F]
+}

--- a/server/app/com/fortysevendeg/exercises/services/interpreters/interpreters.scala
+++ b/server/app/com/fortysevendeg/exercises/services/interpreters/interpreters.scala
@@ -5,7 +5,14 @@
 
 package com.fortysevendeg.exercises.services.interpreters
 
-import cats.{ Monad, Eval, ~>, ApplicativeError, Applicative }
+import com.fortysevendeg.exercises.app.C01
+import com.fortysevendeg.exercises.app.C02
+import com.fortysevendeg.github4s.GithubResponses.{ GHResult, GHResponse }
+import com.fortysevendeg.github4s.app._
+import com.fortysevendeg.github4s.Github
+import com.fortysevendeg.github4s.Github._
+import com.fortysevendeg.github4s.free.interpreters.{ Interpreters ⇒ GithubInterpreters }
+import cats._
 import cats.data.Xor
 import cats.free.Free
 import com.fortysevendeg.exercises.app._
@@ -28,19 +35,20 @@ trait Interpreters[M[_]] {
 
   implicit def interpreters(
     implicit
-    A: ApplicativeError[M, Throwable],
+    A: MonadError[M, Throwable],
     T: Transactor[M]
   ): ExercisesApp ~> M = {
     val exerciseAndUserInterpreter: C01 ~> M = exerciseOpsInterpreter or userOpsInterpreter
     val userAndUserProgressInterpreter: C02 ~> M = userProgressOpsInterpreter or exerciseAndUserInterpreter
-    val all: ExercisesApp ~> M = dbOpsInterpreter or userAndUserProgressInterpreter
+    val c03Interpreter: C03 ~> M = githubOpsInterpreter or userAndUserProgressInterpreter
+    val all: ExercisesApp ~> M = dbOpsInterpreter or c03Interpreter
     all
   }
 
   /**
    * Lifts Exercise Ops to an effect capturing Monad such as Task via natural transformations
    */
-  implicit def exerciseOpsInterpreter(implicit A: ApplicativeError[M, Throwable]): ExerciseOp ~> M = new (ExerciseOp ~> M) {
+  implicit def exerciseOpsInterpreter(implicit A: MonadError[M, Throwable]): ExerciseOp ~> M = new (ExerciseOp ~> M) {
 
     import com.fortysevendeg.exercises.services.ExercisesService._
 
@@ -51,7 +59,7 @@ trait Interpreters[M[_]] {
     }
   }
 
-  implicit def userOpsInterpreter(implicit A: ApplicativeError[M, Throwable], T: Transactor[M], UR: UserRepository): UserOp ~> M = new (UserOp ~> M) {
+  implicit def userOpsInterpreter(implicit A: MonadError[M, Throwable], T: Transactor[M], UR: UserRepository): UserOp ~> M = new (UserOp ~> M) {
 
     import UR._
 
@@ -79,20 +87,44 @@ trait Interpreters[M[_]] {
     }
   }
 
-  implicit def dbOpsInterpreter(implicit A: ApplicativeError[M, Throwable]): DBResult ~> M = new (DBResult ~> M) {
+  implicit def dbOpsInterpreter(implicit A: MonadError[M, Throwable]): DBResult ~> M = new (DBResult ~> M) {
 
     def apply[A](fa: DBResult[A]): M[A] = fa match {
       case DBSuccess(value) ⇒ A.pure(value)
       case DBFailure(error) ⇒ A.raiseError(error)
     }
   }
+
+  implicit def githubOpsInterpreter(implicit A: MonadError[M, Throwable]): GithubOp ~> M = new (GithubOp ~> M) {
+
+    def apply[A](fa: GithubOp[A]): M[A] = {
+
+      object ProdGHInterpreters extends GithubInterpreters[M]
+      implicit val I: GitHub4s ~> M = ProdGHInterpreters.interpreters
+
+      fa match {
+        case GetAuthorizeUrl(client_id, redirect_uri, scopes) ⇒ ghResponseToEntity(Github().auth.authorizeUrl(client_id, redirect_uri, scopes).exec[M])
+        case GetAccessToken(client_id, client_secret, code, redirect_uri, state) ⇒ ghResponseToEntity(Github().auth.getAccessToken(client_id, client_secret, code, redirect_uri, state).exec[M])
+        case GetAuthUser(accessToken) ⇒ ghResponseToEntity(Github(accessToken).users.getAuth.exec[M])
+        case GetContributions(owner, repo, path) ⇒ ghResponseToEntity(Github().repos.listCommits(owner, repo, None, Option(path)).exec[M])
+
+      }
+    }
+
+    private def ghResponseToEntity[T](response: M[GHResponse[T]]): M[T] = A.flatMap(response) {
+      case Xor.Right(GHResult(result, status, headers)) ⇒ A.pure(result)
+      case Xor.Left(e)                                  ⇒ A.raiseError[T](e)
+    }
+
+  }
+
 }
 
 /** Production based interpreters lifting ops to the effect capturing scalaz.concurrent.Task **/
 trait ProdInterpreters extends Interpreters[Task] with TaskInstances
 
 /** Test based interpreters lifting ops to their result identity **/
-trait TestInterpreters extends Interpreters[cats.Id] with IdInstances
+trait TestInterpreters extends Interpreters[Id] with IdInstances
 
 object FreeExtensions {
 
@@ -137,20 +169,15 @@ trait TaskInstances {
 }
 
 trait IdInstances {
-  implicit def idApplicativeError(
-    implicit
-    I: Applicative[cats.Id]
-  ): ApplicativeError[cats.Id, Throwable] = new ApplicativeError[cats.Id, Throwable] {
+  implicit val idMonad: Monad[Id] with MonadError[Id, Throwable] = new Monad[Id] with MonadError[Id, Throwable] {
 
-    import cats.Id
+    override def pure[A](x: A): Id[A] = idMonad.pure(x)
 
-    override def pure[A](x: A): Id[A] = I.pure(x)
+    override def ap[A, B](ff: Id[A ⇒ B])(fa: Id[A]): Id[B] = idMonad.ap(ff)(fa)
 
-    override def ap[A, B](ff: Id[A ⇒ B])(fa: Id[A]): Id[B] = I.ap(ff)(fa)
+    override def map[A, B](fa: Id[A])(f: Id[A ⇒ B]): Id[B] = idMonad.map(fa)(f)
 
-    override def map[A, B](fa: Id[A])(f: Id[A ⇒ B]): Id[B] = I.map(fa)(f)
-
-    override def product[A, B](fa: Id[A], fb: Id[B]): Id[(A, B)] = I.product(fa, fb)
+    override def product[A, B](fa: Id[A], fb: Id[B]): Id[(A, B)] = idMonad.product(fa, fb)
 
     override def raiseError[A](e: Throwable): Id[A] =
       throw e

--- a/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
+++ b/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
@@ -15,8 +15,6 @@ object OAuth2 {
 
   lazy val githubAuthId = application.configuration.getString("github.client.id").getOrElse("")
   lazy val githubAuthSecret = application.configuration.getString("github.client.secret").getOrElse("")
-  lazy val githubOwner = application.configuration.getString("github.owner").getOrElse("")
-  lazy val githubRepo = application.configuration.getString("github.repo").getOrElse("")
   def callbackUrl(implicit req: Request[AnyContent]) = com.fortysevendeg.exercises.controllers.routes.OAuthController.callback(None, None).absoluteURL()
   val successUrl = com.fortysevendeg.exercises.controllers.routes.OAuthController.success()
 

--- a/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
+++ b/server/app/com/fortysevendeg/exercises/utils/OAuth2.scala
@@ -5,145 +5,19 @@
 
 package com.fortysevendeg.exercises.utils
 
-import cats.data.Xor
-import cats.std.option._
-import cats.syntax.cartesian._
-import com.fortysevendeg.exercises.app._
-import com.fortysevendeg.exercises.persistence.domain.UserCreation
-import com.fortysevendeg.exercises.services.free.UserOps
-import com.fortysevendeg.exercises.services.interpreters.ProdInterpreters
-import com.fortysevendeg.exercises.services.interpreters.FreeExtensions._
-import doobie.imports._
-import play.api.http.{ HeaderNames, MimeTypes }
-import play.api.libs.ws._
-import play.api.mvc.{ Action, Controller, Results, BodyParsers }
+import play.api.mvc.{ Request, AnyContent }
 import play.api.{ Application, Play }
-import play.api.libs.json._
-import play.api.libs.functional.syntax._
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import scalaz.concurrent.Task
+import com.fortysevendeg.exercises.controllers.OAuthController
 
 object OAuth2 {
 
   implicit def application: Application = Play.current
 
-  lazy val githubAuthId = application.configuration.getString("github.client.id").get
-  lazy val githubAuthSecret = application.configuration.getString("github.client.secret").get
+  lazy val githubAuthId = application.configuration.getString("github.client.id").getOrElse("")
+  lazy val githubAuthSecret = application.configuration.getString("github.client.secret").getOrElse("")
+  lazy val githubOwner = application.configuration.getString("github.owner").getOrElse("")
+  lazy val githubRepo = application.configuration.getString("github.repo").getOrElse("")
+  def callbackUrl(implicit req: Request[AnyContent]) = com.fortysevendeg.exercises.controllers.routes.OAuthController.callback(None, None).absoluteURL()
+  val successUrl = com.fortysevendeg.exercises.controllers.routes.OAuthController.success()
 
-  def getAuthorizationUrl(redirectUri: String, scope: String, state: String): String = {
-    val baseUrl = application.configuration.getString("github.redirect.url").get
-    baseUrl.format(githubAuthId, redirectUri, scope, state)
-  }
-}
-
-class OAuth2Controller(
-    implicit
-    userOps: UserOps[ExercisesApp],
-    T: Transactor[Task],
-    ws: WSClient
-) extends Controller with ProdInterpreters {
-
-  import OAuth2._
-
-  def githubTokenRequest(githubClientToken: String, githubSecretToken: String, code: String) = {
-    ws.url("https://github.com/login/oauth/access_token")
-      .withQueryString(
-        "client_id" → githubClientToken,
-        "client_secret" → githubSecretToken,
-        "code" → code
-      )
-      .withHeaders(HeaderNames.ACCEPT → MimeTypes.JSON)
-      .post(Results.EmptyContent())
-  }
-
-  def fetchGitHubToken(githubClientToken: String, githubSecretToken: String, code: String): Future[Option[String]] = for {
-    response ← githubTokenRequest(githubClientToken, githubSecretToken, code)
-    theToken ← Future.successful((response.json \ "access_token").asOpt[String])
-  } yield theToken
-
-  case class GitHubUser(
-    login: String,
-    name: Option[String],
-    githubId: Long,
-    avatarUrl: String,
-    htmlUrl: String,
-    email: Option[String]
-  )
-
-  implicit val readGithubUser: Reads[GitHubUser] = (
-    (JsPath \ "login").read[String] and
-    (JsPath \ "name").readNullable[String] and
-    (JsPath \ "id").read[Long] and
-    (JsPath \ "avatar_url").read[String] and
-    (JsPath \ "html_url").read[String] and
-    (JsPath \ "email").readNullable[String]
-  )(GitHubUser.apply _)
-
-  def githubUserRequest(authToken: String) =
-    ws.url("https://api.github.com/user").withHeaders(HeaderNames.AUTHORIZATION → s"token $authToken").get()
-
-  def fetchGitHubUser(authToken: String): Future[Option[GitHubUser]] = {
-    githubUserRequest(authToken).map(_.json.validate[GitHubUser] match {
-      case ok: JsSuccess[GitHubUser] ⇒ Some(ok.get)
-      case _ ⇒ None
-    })
-  }
-
-  def getToken(code: String): Future[String] = for {
-    maybeToken ← fetchGitHubToken(githubAuthId, githubAuthSecret, code)
-    err = Future.failed[String](new IllegalStateException("Unable to retrieve GitHub token."))
-    response ← maybeToken.fold(err)(Future.successful(_))
-  } yield response
-
-  def callback(codeOpt: Option[String] = None, stateOpt: Option[String] = None) = Action.async { implicit request ⇒
-    lazy val missingParams = Future.successful(BadRequest("Missing query parameters: make sure `code` and `state` are present."))
-
-    val params: Option[(String, String, String)] = (codeOpt |@| stateOpt |@| request.session.get("oauth-state")).tupled
-
-    params.fold(missingParams)(params ⇒ {
-      val (code, state, oauthState) = params
-      if (state == oauthState) {
-        (for {
-          accessToken ← getToken(code)
-          successURL = com.fortysevendeg.exercises.utils.routes.OAuth2Controller.success()
-        } yield Redirect(successURL).withSession("oauth-token" → accessToken)).recover {
-          case ex: IllegalStateException ⇒ Unauthorized(ex.getMessage)
-        }
-      } else {
-        Future.successful(BadRequest("Invalid github login"))
-      }
-    })
-  }
-
-  def success() = Action.async { request ⇒
-    lazy val unauthorized = Future.successful(Unauthorized("Missing OAuth token"))
-    request.session.get("oauth-token").fold(unauthorized) { authToken ⇒
-      for {
-        maybeGhUser ← fetchGitHubUser(authToken)
-        response <- maybeGhUser.fold(Future.successful(InternalServerError("Failed to fetch GitHub profile")))(ghUser ⇒
-          userOps.getOrCreate(
-            UserCreation.Request(
-              ghUser.login,
-              ghUser.name,
-              ghUser.githubId.toString,
-              ghUser.avatarUrl,
-              ghUser.htmlUrl,
-              ghUser.email
-            )
-          ).runFuture map {
-              case Xor.Right(_) ⇒ Redirect(
-                request.headers.get("referer") match {
-                  case Some(url) if !url.contains("github") ⇒ url
-                  case _ ⇒ "/"
-                }
-              ).withSession("oauth-token" → authToken, "user" → ghUser.login)
-              case Xor.Left(_) ⇒ InternalServerError("Failed to save user information")
-            })
-      } yield response
-    }
-  }
-
-  def logout() = Action(Redirect("/").withNewSession)
 }

--- a/server/app/views/templates/library/commits_modal.scala.html
+++ b/server/app/views/templates/library/commits_modal.scala.html
@@ -1,3 +1,4 @@
+@(contributions: shared.Contributions)(implicit request: RequestHeader)
 <!-- Modal -->
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
   <div class="modal-dialog" role="document">
@@ -9,90 +10,26 @@
       </div>
       <div class="modal-body">
         <ul>
-          <li>Commits on Feb 22, 2016</li>
 
-          <li>
-            <div class="row">
-              <div class="col-xs-8 col-md-8">
-                <img src="https://avatars0.githubusercontent.com/u/310363?v=3&s=72" alt="">
-                <p>Make site use output from SBT plugin</p>
-                <span>
-                  <a href="https://github.com/47deg/scala-exercises">andyscott</a>
-                  committed 17 hours ago</span>
+          @for(commit <- contributions.commits) {
+            <li>
+              <div class="row">
+                <div class="col-xs-9 col-md-9">
+                  <a href="@commit.authorUrl"><img src="@commit.avatarUrl" alt=""></a>
+                  <p>@commit.message</p>
+                  <span>
+                    <a href="@commit.authorUrl">@commit.login</a>
+                    committed @commit.date</span>
+                </div>
+                <div class="col-xs-3 col-md-3">
+                  <a href="@commit.url" target="_blank" type="button" class="btn btn-default btn-sm">View on GitHub </a>
+                </div>
               </div>
-              <div class="col-xs-4 col-md-4">
-                <button type="button" class="btn btn-default btn-sm">Link to GitHub </button>
-              </div>
-            </div>
-          </li>
-
-          <li>
-            <div class="row">
-              <div class="col-xs-8 col-md-8">
-                <img src="https://avatars3.githubusercontent.com/u/409039?v=3&s=72" alt="">
-                <p>Use ScalaCheck for testing boolean conversion</p>
-                <span>
-                  <a href="https://github.com/47deg/scala-exercises">dialelo</a>
-                  committed 21 hours ago</span>
-              </div>
-              <div class="col-xs-4 col-md-4">
-                <button type="button" class="btn btn-default btn-sm">Link to GitHub </button>
-              </div>
-            </div>
-          </li>
-
-          <li>
-            <div class="row">
-              <div class="col-xs-8 col-md-8">
-                <img src="https://avatars1.githubusercontent.com/u/456796?v=3&s=72" alt="">
-                <p>Progress toward free architecture</p>
-                <span>
-                  <a href="https://github.com/47deg/scala-exercises">raulraja</a>
-                  committed 22 hours ago</span>
-              </div>
-              <div class="col-xs-4 col-md-4">
-                <button type="button" class="btn btn-default btn-sm">Link to GitHub </button>
-              </div>
-            </div>
-          </li>
+            </li>
+          }
 
         </ul>
-        <ul>
-          <li>Commits on Feb 21, 2016</li>
 
-          <li>
-            <div class="row">
-              <div class="col-xs-8 col-md-8">
-                <img src="https://avatars0.githubusercontent.com/u/4879373" alt="">
-                <p>SE-222 Adds the doobie contrib for postgresql</p>
-                <span>
-                  <a href="https://github.com/47deg/scala-exercises">juanpedromoreno</a>
-                  committed 23 hours ago</span>
-              </div>
-              <div class="col-xs-4 col-md-4">
-                <button type="button" class="btn btn-default btn-sm">Link to GitHub </button>
-              </div>
-            </div>
-          </li>
-
-          <li>
-            <div class="row">
-              <div class="col-xs-8 col-md-8">
-                <img src="https://avatars0.githubusercontent.com/u/315070?v=3&s=72" alt="">
-                <p>Fix issue related to ambiguous reference to jquery</p>
-                <span>
-                  <a href="https://github.com/47deg/scala-exercises">rafaparadela</a>
-                  committed 3 days ago</span>
-              </div>
-              <div class="col-xs-4 col-md-4">
-                <button type="button" class="btn btn-default btn-sm">Link to GitHub </button>
-              </div>
-            </div>
-          </li>
-
-
-
-        </ul>
       </div>
     </div>
   </div>

--- a/server/app/views/templates/library/contributors.scala.html
+++ b/server/app/views/templates/library/contributors.scala.html
@@ -1,34 +1,14 @@
+@(contributions: shared.Contributions)(implicit request: RequestHeader)
 <ul>
-  <li><a href="#" data-toggle="modal" data-target="#myModal"><i class="fa fa-user"></i>6 contributors</a>
+  <li><a href="#" data-toggle="modal" data-target="#myModal"><i class="fa fa-user"></i>@contributions.contributors.size contributors</a>
   </li>
-  <li>
-    <a data-toggle="tooltip" data-placement="bottom" title="rafaparadela" href="https://github.com/rafaparadela" target="_blank">
-      <img src="http://avatars3.githubusercontent.com/u/315070" alt="rafaparadela">
-    </a>
-  </li>
-  <li>
-    <a data-toggle="tooltip" data-placement="bottom" title="raulraja" href="https://github.com/raulraja" target="_blank">
-      <img src="https://avatars0.githubusercontent.com/u/456796" alt="raulraja">
-    </a>
-  </li>
-  <li>
-    <a data-toggle="tooltip" data-placement="bottom" title="dialelo" href="https://github.com/dialelo" target="_blank">
-      <img src="https://avatars2.githubusercontent.com/u/409039" alt="dialelo">
-    </a>
-  </li>
-  <li>
-    <a data-toggle="tooltip" data-placement="bottom" title="andyscott" href="https://github.com/andyscott" target="_blank">
-      <img src="https://avatars1.githubusercontent.com/u/310363?v=3&s=460" alt="andyscott">
-    </a>
-  </li>
-  <li>
-    <a data-toggle="tooltip" data-placement="bottom" title="juanpedromoreno" href="https://github.com/juanpedromoreno" target="_blank">
-      <img src="https://avatars3.githubusercontent.com/u/4879373?v=3&s=460" alt="juanpedromoreno">
-    </a>
-  </li>
-  <li>
-    <a data-toggle="tooltip" data-placement="bottom" title="israelperezglez" href="https://github.com/israelperezglez" target="_blank">
-      <img src="https://avatars1.githubusercontent.com/u/646886?v=3&s=460" alt="israelperezglez">
-    </a>
-  </li>
+
+  @for(contributor <- contributions.contributors) {
+    <li>
+      <a data-toggle="tooltip" data-placement="bottom" title="@contributor.login" href="@contributor.authorUrl" target="_blank">
+        <img src="@contributor.avatarUrl" alt="@contributor.login">
+      </a>
+    </li>
+  }
+
 </ul>

--- a/server/app/views/templates/library/footer.scala.html
+++ b/server/app/views/templates/library/footer.scala.html
@@ -1,7 +1,7 @@
-@(githubBaseUrl: String, path: String)(implicit request: RequestHeader)
+@()(implicit request: RequestHeader)
 <footer id="bottom" class="light">
   <div class="container-fluid">
-    <div class="col-md-8">
+    <div class="col-md-12">
       <svg viewBox="0 24 30 19" width="30" height="19">
         <use xlink:href="@routes.Assets.at("images/sprite-images.svg#brand-dark")"/>
       </svg>
@@ -9,9 +9,6 @@
       @templates.base.footerLinks()
       
      </div>
-    <div class="col-md-4">
-      <p class="text-right"><a href="https://github.com/@githubBaseUrl/blob/master/@path" target="_blank">View on GitHub</a></p>
-    </div>
   </div>
 </footer>
 

--- a/server/app/views/templates/library/footer.scala.html
+++ b/server/app/views/templates/library/footer.scala.html
@@ -1,3 +1,4 @@
+@(githubBaseUrl: String, path: String)(implicit request: RequestHeader)
 <footer id="bottom" class="light">
   <div class="container-fluid">
     <div class="col-md-8">
@@ -9,7 +10,7 @@
       
      </div>
     <div class="col-md-4">
-      <p class="text-right"><a href="#">View on GitHub</a></p>
+      <p class="text-right"><a href="https://github.com/@githubBaseUrl/blob/master/@path" target="_blank">View on GitHub</a></p>
     </div>
   </div>
 </footer>

--- a/server/app/views/templates/library/index.scala.html
+++ b/server/app/views/templates/library/index.scala.html
@@ -1,4 +1,4 @@
-@(library: shared.Library, section: shared.Section, progress: shared.LibraryProgress, user: Option[shared.User] = None, redirectUrl: Option[String] = Some("#"), contributions: shared.Contributions, githubBaseUrl: String)(implicit request: RequestHeader)
+@(library: shared.Library, section: shared.Section, progress: shared.LibraryProgress, user: Option[shared.User] = None, redirectUrl: Option[String] = Some("#"), contributions: shared.Contributions)(implicit request: RequestHeader)
 
 @import com.fortysevendeg.exercises.utils.StringUtils._
 
@@ -84,7 +84,7 @@
               <div class="content-header clearfix">
                 <h2 class="pull-left">@section.name.humanizeUnderscore</h2>
                 <div class="add-exercises pull-right hidden-xs">
-                  <a href="https://github.com/@githubBaseUrl/edit/master/@section.path.getOrElse("")" target="_blank" type="button" class="btn btn-default btn-sm">Add exercises</a>
+                  <a href="https://github.com/@library.owner/@library.repository/blob/master@section.path.getOrElse("")" target="_blank" type="button" class="btn btn-default btn-sm">View on GitHub</a>
                 </div>
               </div>
 
@@ -104,7 +104,7 @@
                 @templates.library.contributors(contributions)
 
                 <ul>
-                  <li> <a href="https://github.com/@githubBaseUrl/edit/master/@section.path.getOrElse("")" target="_blank"><i class="fa fa-pencil"></i>Edit exercises</a>
+                  <li> <a href="https://github.com/@library.owner/@library.repository/edit/master@section.path.getOrElse("")" target="_blank"><i class="fa fa-pencil"></i>Edit exercises</a>
                   </li>
                 </ul>
               </div>
@@ -114,7 +114,7 @@
         </div>
 
       </section>
-      @templates.library.footer(githubBaseUrl, section.path.getOrElse(""))
+      @templates.library.footer()
     </div>
 
     @templates.library.commits_modal(contributions)

--- a/server/app/views/templates/library/index.scala.html
+++ b/server/app/views/templates/library/index.scala.html
@@ -1,4 +1,4 @@
-@(library: shared.Library, section: shared.Section, progress: shared.LibraryProgress, user: Option[shared.User] = None, redirectUrl: Option[String] = Some("#"))(implicit request: RequestHeader)
+@(library: shared.Library, section: shared.Section, progress: shared.LibraryProgress, user: Option[shared.User] = None, redirectUrl: Option[String] = Some("#"), contributions: shared.Contributions, githubBaseUrl: String)(implicit request: RequestHeader)
 
 @import com.fortysevendeg.exercises.utils.StringUtils._
 
@@ -84,7 +84,7 @@
               <div class="content-header clearfix">
                 <h2 class="pull-left">@section.name.humanizeUnderscore</h2>
                 <div class="add-exercises pull-right hidden-xs">
-                  <button type="button" class="btn btn-default btn-sm">Add exercises</button>
+                  <a href="https://github.com/@githubBaseUrl/edit/master/@section.path.getOrElse("")" target="_blank" type="button" class="btn btn-default btn-sm">Add exercises</a>
                 </div>
               </div>
 
@@ -101,10 +101,10 @@
 
               <div class="contributors clearfix">
 
-                @templates.library.contributors()
+                @templates.library.contributors(contributions)
 
                 <ul>
-                  <li> <a href="#"><i class="fa fa-pencil"></i>Edit exercises</a>
+                  <li> <a href="https://github.com/@githubBaseUrl/edit/master/@section.path.getOrElse("")" target="_blank"><i class="fa fa-pencil"></i>Edit exercises</a>
                   </li>
                 </ul>
               </div>
@@ -114,10 +114,10 @@
         </div>
 
       </section>
-      @templates.library.footer()
+      @templates.library.footer(githubBaseUrl, section.path.getOrElse(""))
     </div>
 
-    @templates.library.commits_modal()
+    @templates.library.commits_modal(contributions)
     @templates.library.mustsignup_modal(redirectUrl)
 
       <!-- JS -->

--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -75,7 +75,6 @@ github.client.id=${?GITHUB_CLIENT_ID}
 github.client.secret="e5194c494a3f96d28a20e9991a519ef567f3958a"
 github.client.secret=${?GITHUB_CLIENT_SECRET}
 
-github.redirect.url="https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=%s&state=%s"
 
 # Exercises
 # ~~~~~~~~~

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -14,10 +14,10 @@ POST /exercises/sections/:libraryName/:sectionName/evaluate com.fortysevendeg.ex
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file controllers.Assets.at(path="/public", file)
 
-# OAuth2 Stuff
-GET /_oauth-callback  com.fortysevendeg.exercises.utils.OAuth2Controller.callback(code: Option[String], state: Option[String])
-GET /_oauth-success   com.fortysevendeg.exercises.utils.OAuth2Controller.success
-GET /logout   com.fortysevendeg.exercises.utils.OAuth2Controller.logout
+# OAuth2
+GET /_oauth-callback  com.fortysevendeg.exercises.controllers.OAuthController.callback(code: Option[String], state: Option[String])
+GET /_oauth-success   com.fortysevendeg.exercises.controllers.OAuthController.success
+GET /logout           com.fortysevendeg.exercises.controllers.OAuthController.logout
 
 # Client-side routing
 GET /javascriptRoutes com.fortysevendeg.exercises.controllers.ApplicationController.javascriptRoutes

--- a/shared/src/main/scala/shared/Contribution.scala
+++ b/shared/src/main/scala/shared/Contribution.scala
@@ -1,0 +1,22 @@
+package shared
+
+case class Contributions(
+    commits:      List[Contribution],
+    contributors: List[Contributor]
+)
+
+case class Contribution(
+    sha:       String,
+    message:   String,
+    date:      String,
+    url:       String,
+    login:     String,
+    avatarUrl: String,
+    authorUrl: String
+)
+
+case class Contributor(
+    login:     String,
+    avatarUrl: String,
+    authorUrl: String
+)

--- a/shared/src/main/scala/shared/Contribution.scala
+++ b/shared/src/main/scala/shared/Contribution.scala
@@ -1,22 +1,22 @@
 package shared
 
 case class Contributions(
-    commits:      List[Contribution],
-    contributors: List[Contributor]
+  commits: List[Contribution],
+  contributors: List[Contributor]
 )
 
 case class Contribution(
-    sha:       String,
-    message:   String,
-    date:      String,
-    url:       String,
-    login:     String,
-    avatarUrl: String,
-    authorUrl: String
+  sha: String,
+  message: String,
+  date: String,
+  url: String,
+  login: String,
+  avatarUrl: String,
+  authorUrl: String
 )
 
 case class Contributor(
-    login:     String,
-    avatarUrl: String,
-    authorUrl: String
+  login: String,
+  avatarUrl: String,
+  authorUrl: String
 )

--- a/shared/src/main/scala/shared/Exercise.scala
+++ b/shared/src/main/scala/shared/Exercise.scala
@@ -7,6 +7,8 @@ import cats.data.Xor
  * A library representing a lib or lang. Ej. stdlib, cats, scalaz...
  */
 case class Library(
+    owner: String,
+    repository: String,
     name: String,
     description: String,
     color: String,

--- a/shared/src/main/scala/shared/Exercise.scala
+++ b/shared/src/main/scala/shared/Exercise.scala
@@ -21,6 +21,7 @@ case class Library(
 case class Section(
   name: String,
   description: Option[String] = None,
+  path: Option[String] = None,
   exercises: List[Exercise] = Nil
 )
 


### PR DESCRIPTION
This PR includes:

- Addition of `owner` and `repository` in Library model.
- Inferring those fields during compilation.
- Integration of Github4s to interact with Github.
- Changes in templates to show contributors, commits, links to editing, etc.

@raulraja Could you review please? Thank you.

FYI Most of these changes were reviewed in this PR: https://github.com/scala-exercises/site/pull/345