### PR TITLE
Retrieve a valid access token for Github requests

### DIFF
--- a/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/Compiler.scala
+++ b/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/Compiler.scala
@@ -102,7 +102,7 @@ case class Compiler() {
 
     def fetchContributions(owner: String, repository: String, path: String): List[ContributionInfo] = {
       println(s"Fetching contributions for repository $owner/$repository file $path")
-      val contribs = Github().repos.listCommits(owner, repository, None, Option(path))
+      val contribs = Github(sys.env.lift("SE_COMPILER_TOKEN")).repos.listCommits(owner, repository, None, Option(path))
       contribs.exec[Eval].value match {
         case Xor.Right(GHResult(result, _, _)) => result.map(commit =>
           ContributionInfo(

--- a/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/Compiler.scala
+++ b/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/Compiler.scala
@@ -102,7 +102,7 @@ case class Compiler() {
 
     def fetchContributions(owner: String, repository: String, path: String): List[ContributionInfo] = {
       println(s"Fetching contributions for repository $owner/$repository file $path")
-      val contribs = Github(sys.env.lift("SE_COMPILER_TOKEN")).repos.listCommits(owner, repository, None, Option(path))
+      val contribs = Github(sys.env.lift("GITHUB_TOKEN")).repos.listCommits(owner, repository, None, Option(path))
       contribs.exec[Eval].value match {
         case Xor.Right(GHResult(result, _, _)) => result.map(commit =>
           ContributionInfo(


### PR DESCRIPTION
This PR fixes #396 . It get an environment variable called `GITHUB_TOKEN` in order to avoid the rate limit exception.

So, you should [create a new personal access token with `repo` scope](https://github.com/settings/tokens/new) and create an env var called `GITHUB_TOKEN` with it.

@dialelo Could you review please? Thank you.

