### PR TITLE
Rename database url env var

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -41,7 +41,7 @@ play.application.loader=com.fortysevendeg.exercises.ExercisesApplicationLoader
 #
 
 db.default.driver=org.postgresql.Driver
-db.default.url=${?HEROKU_POSTGRESQL_ORANGE_URL}
+db.default.url=${?DATABASE_URL}
 play.db.prototype.hikaricp.connectionTestQuery=SELECT 1
 play.db.prototype.hikaricp.registerMbeans=true
 


### PR DESCRIPTION
DO NOT MERGE!

It seems like Heroku create an environment variable with datasource data, called `DATABASE_URL` for review apps. Let's try if they can be properly deployed if we retrieve this info to instantiate data source.