### PR TITLE
Rename database url env var

### DIFF
--- a/server/conf/application.conf
+++ b/server/conf/application.conf
@@ -42,6 +42,7 @@ play.application.loader=com.fortysevendeg.exercises.ExercisesApplicationLoader
 
 db.default.driver=org.postgresql.Driver
 db.default.url=${?HEROKU_POSTGRESQL_ORANGE_URL}
+db.default.url=${?DATABASE_URL}
 play.db.prototype.hikaricp.connectionTestQuery=SELECT 1
 play.db.prototype.hikaricp.registerMbeans=true
 


### PR DESCRIPTION
This PR closes #404.

- In prod, database connection data is retrieved from `HEROKU_POSTGRESQL_ORANGE_URL`.
- In preview apps, from `DATABASE_URL` (generated dynamically by Heroku).

@raulraja @dialelo  Makes sense to you both?