### PR TITLE
Accumulate imports in order

### DIFF
--- a/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/SourceTextExtraction.scala
+++ b/compiler/src/main/scala/com/fortysevendeg/exercises/compiler/SourceTextExtraction.scala
@@ -77,8 +77,12 @@ class SourceTextExtraction {
           k → new ExtractedComment(v._2.raw, commentFactory.parse(v._2))
       }
 
-      val imports = extraction.imports.map(expandPath)
-        .groupBy(_._1).mapValues(_.map(_._2))
+      val rawImports = extraction.imports
+      val paths = rawImports.map(expandPath)
+
+      val imports = paths
+        .groupBy(_._1)
+        .mapValues(_.map(_._2))
 
       val methods = extraction.methods.map(expandPath).map {
         case (k, v) ⇒
@@ -234,7 +238,7 @@ object SourceTextExtraction {
         //println("looking at import " + imp + " at position " + acc.position)
         //println("previous import processed " + acc.imports)
         acc.copy(
-          imports = (path, (acc.position, imp)) :: acc.imports,
+          imports = acc.imports :+ (path, (acc.position, imp)),
           position = acc.position + 1
         )
       }

--- a/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/SourceTextExtractionSpec.scala
+++ b/compiler/src/test/scala/com/fortysevendeg/exercises/compiler/SourceTextExtractionSpec.scala
@@ -61,21 +61,26 @@ class SourceTextExtractionSpec extends FunSpec with Matchers with Inside {
     it("isolates imports to a given source file") {
       val source1 = """
         import a._
+        import b._
         object Object1 {
           /** Method */
-          def method() {}
+          def method() {
+          }
         }
         """
 
       val source2 = """
-        import a._
+        import c._
+        import d._
+
         /** Object 2
           * @param name Object 2
           */
         object Object2 {
-          import b2._
+          import obj2._
           /** Method */
-          def method() {}
+          def method() {
+          }
         }
         """
 
@@ -85,13 +90,13 @@ class SourceTextExtractionSpec extends FunSpec with Matchers with Inside {
       // Should capture exactly 1 import for Object1.method
       inside(res.methods.get("Object1" :: "method" :: Nil)) {
         case Some(method) ⇒
-          method.imports.length should equal(1)
+          method.imports shouldEqual List("import a._", "import b._")
       }
 
       // Should capture exactly 2 imports for Object2.method
       inside(res.methods.get("Object2" :: "method" :: Nil)) {
         case Some(method) ⇒
-          method.imports.length should equal(2)
+          method.imports shouldEqual List("import c._", "import d._", "import obj2._")
       }
 
     }


### PR DESCRIPTION
Fixes a bug we found in the compiler: emitting the imports in reverse order. @raulraja @rafaparadela please take a look.